### PR TITLE
Implemented Kaomoji menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ module.exports = class Kaomoji extends Plugin {
         } catch {
           return {
             send: false,
-            result:
-							'There aren\'t any kaomoji for that emotion! Pick an emotion from the list. If you need help, check out <https://github.com/davidjcralph/kaomoji>!'
+            result: 'There aren\'t any kaomoji for that emotion! Pick an emotion from the list. If you need help, check out <https://github.com/davidjcralph/kaomoji>!'
           };
         }
       },

--- a/index.js
+++ b/index.js
@@ -2,47 +2,74 @@ const emotes = require('./emotes.json');
 const { Plugin } = require('powercord/entities');
 
 module.exports = class Kaomoji extends Plugin {
-	startPlugin() {
-		powercord.api.commands.registerCommand({
-			command: 'kaomoji',
-			aliases: ['kao'],
-			description: 'Appends a kaomoji to your message!',
-			usage: '{c} [ emotion ]',
-			executor: (args) => {
-				const emoteSelection = emotes[args.shift()];
-				if (emoteSelection) {
-					return {
-						send: true,
-						result: `${args.join(' ')} ${
-							emoteSelection[Math.floor(Math.random() * emoteSelection.length)]
-						}`,
-					};
-				}
-				return {
-					send: false,
-					result:
-						'There aren\'t any kaomoji for that emotion! Pick an emotion from the list. If you need help, check out <https://github.com/davidjcralph/kaomoji>!',
-				};
-			},
-			autocomplete: (args) => {
-				if (args.length !== 1) {
-					return false;
-				}
+  startPlugin () {
+    powercord.api.commands.registerCommand({
+      command: 'kaomoji',
+      aliases: [ 'kao' ],
+      description: 'Appends a kaomoji to your message!',
+      usage: '{c} [ emotion ]',
+      executor: (args) => {
+        try {
+          const emoteSelection = emotes[args.shift()][args.shift()];
+          if (emoteSelection) {
+            return {
+              send: true,
+              result: emoteSelection
+            };
+          }
+          throw new Error();
+        } catch {
+          return {
+            send: false,
+            result:
+							'There aren\'t any kaomoji for that emotion! Pick an emotion from the list. If you need help, check out <https://github.com/davidjcralph/kaomoji>!'
+          };
+        }
+      },
+      autocomplete: (args) => {
+        if (args.length < 1 || args.length > 2) {
+          return false;
+        } else if (args.length === 1) {
+          return {
+            commands: Object.keys(emotes)
+              .filter((e) => e.includes(args[0].toLowerCase()))
+              .map((e) => ({
+                command: e,
+                description: ''
+              })),
+            header: 'Kaomoji Emotions'
+          };
+        } else if (args.length === 2) {
+          try {
+            const object = emotes[args.shift()];
+            return {
+              commands: object.map((item, index) => ({
+                command: index,
+                description: item
+              }))
+            };
+          } catch {
+            return {
+              commands: [],
+              header: 'No Emojis Found :('
+            };
+          }
+        }
 
-				return {
-					commands: Object.keys(emotes)
-						.filter((e) => e.includes(args[0].toLowerCase()))
-						.map((e) => ({
-							command: e,
-							description: '',
-						})),
-					header: 'Kaomoji Emotions',
-				};
-			},
-		});
-	}
+        return {
+          commands: Object.keys(emotes)
+            .filter((e) => e.includes(args[0].toLowerCase()))
+            .map((e) => ({
+              command: e,
+              description: ''
+            })),
+          header: 'Kaomoji Emotions'
+        };
+      }
+    });
+  }
 
-	pluginWillUnload() {
-		powercord.api.commands.unregisterCommand('kaomoji');
-	}
+  pluginWillUnload () {
+    powercord.api.commands.unregisterCommand('kaomoji');
+  }
 };

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = class Kaomoji extends Plugin {
           if (emoteSelection) {
             return {
               send: true,
-              result: emoteSelection
+              result: `${args.join(' ')} ${emoteSelection}`
             };
           }
           throw new Error();


### PR DESCRIPTION
Hello! So I saw this plugin after installing Powercord and I really liked using this. I thought that it would be cool if you could choose which Kaomoji you would like to send based on the category so I forked the repo and implemented it, though the code might be a bit messy because I don't have much experience with the API and IntelliSense isn't working properly for some reason haha.

Heres a demo of it in action:
![kaomoji_test](https://user-images.githubusercontent.com/2920970/123604099-b8748b80-d824-11eb-858e-9de491b0d933.gif)
